### PR TITLE
Add bounding_box, line_with_normals, and helix node

### DIFF
--- a/blackjack_engine/src/engine_tests.rs
+++ b/blackjack_engine/src/engine_tests.rs
@@ -123,7 +123,7 @@ pub fn test_examples_folder() {
             },
             bounding_box_size: Vec3 {
                 x: 7.0,
-                y: 3.9965458,
+                y: 4.0,
                 z: 7.0,
             },
         },

--- a/blackjack_engine/src/engine_tests.rs
+++ b/blackjack_engine/src/engine_tests.rs
@@ -37,6 +37,7 @@ struct Example {
     vertices: usize,
     halfedges: usize,
     faces: usize,
+    bounding_box: primitives::Box, // TODO: enable std::marker::Copy trait on primitives::Box
 }
 
 fn run_example(example: &Example, rt: &LuaRuntime) -> ProgramResult {
@@ -66,24 +67,40 @@ pub fn test_examples_folder() {
             vertices: 8,
             halfedges: 24,
             faces: 6,
+            bounding_box: primitives::Box::build(
+                Vec3 { x: 0, y: 0, z: 0 }, // TODO: fix center and size
+                Vec3 { x: 0, y: 0, z: 0 },
+            ),
         },
         Example {
             path: "../examples/tp_cutter.bjk",
             vertices: 184,
             halfedges: 680,
             faces: 170,
+            bounding_box: primitives::Box::build(
+                Vec3 { x: 0, y: 0, z: 0 }, // TODO: fix center and size
+                Vec3 { x: 0, y: 0, z: 0 },
+            ),
         },
         Example {
             path: "../examples/stylised_sword.bjk",
             vertices: 284,
             halfedges: 988,
             faces: 228,
+            bounding_box: primitives::Box::build(
+                Vec3 { x: 0, y: 0, z: 0 }, // TODO: fix center and size
+                Vec3 { x: 0, y: 0, z: 0 },
+            ),
         },
         Example {
             path: "../examples/extrude-quad-along-helix.bjk",
             vertices: 148,
             halfedges: 584,
             faces: 144,
+            bounding_box: primitives::Box::build(
+                Vec3 { x: 0, y: 0, z: 0 }, // TODO: fix center and size
+                Vec3 { x: 0, y: 0, z: 0 },
+            ),
         },
     ];
 
@@ -94,7 +111,7 @@ pub fn test_examples_folder() {
             assert_eq!(h.read_connectivity().num_vertices(), example.vertices);
             assert_eq!(h.read_connectivity().num_halfedges(), example.halfedges);
             assert_eq!(h.read_connectivity().num_faces(), example.faces);
-            assert_eq!(h.read_positions().face_vertex_average(), example.faces);
+            assert_eq!(h.bounding_box(), example.bounding_box);
         } else {
             panic!("Expected a mesh")
         }

--- a/blackjack_engine/src/engine_tests.rs
+++ b/blackjack_engine/src/engine_tests.rs
@@ -118,13 +118,13 @@ pub fn test_examples_folder() {
             faces: 144,
             bounding_box_center: Vec3 {
                 x: 0.0,
-                y: 0.0,
+                y: 1.5,
                 z: 0.0,
             },
             bounding_box_size: Vec3 {
-                x: 0.0,
-                y: 0.0,
-                z: 0.0,
+                x: 6.9999986,
+                y: 3.9965458,
+                z: 6.9999986,
             },
         },
     ];

--- a/blackjack_engine/src/engine_tests.rs
+++ b/blackjack_engine/src/engine_tests.rs
@@ -79,6 +79,12 @@ pub fn test_examples_folder() {
             halfedges: 988,
             faces: 228,
         },
+        Example {
+            path: "../examples/extrude-quad-along-helix.bjk",
+            vertices: 148,
+            halfedges: 584,
+            faces: 144,
+        },
     ];
 
     for example in examples {
@@ -88,6 +94,7 @@ pub fn test_examples_folder() {
             assert_eq!(h.read_connectivity().num_vertices(), example.vertices);
             assert_eq!(h.read_connectivity().num_halfedges(), example.halfedges);
             assert_eq!(h.read_connectivity().num_faces(), example.faces);
+            assert_eq!(h.read_positions().face_vertex_average(), example.faces);
         } else {
             panic!("Expected a mesh")
         }

--- a/blackjack_engine/src/engine_tests.rs
+++ b/blackjack_engine/src/engine_tests.rs
@@ -74,9 +74,9 @@ pub fn test_examples_folder() {
                 z: 0.0,
             },
             bounding_box_size: Vec3 {
-                x: 0.0,
-                y: 0.0,
-                z: 0.0,
+                x: 1.0,
+                y: 1.0,
+                z: 1.0,
             },
         },
         Example {
@@ -86,29 +86,29 @@ pub fn test_examples_folder() {
             faces: 170,
             bounding_box_center: Vec3 {
                 x: 0.0,
-                y: 0.0,
+                y: 0.29355407,
                 z: 0.0,
             },
             bounding_box_size: Vec3 {
-                x: 0.0,
-                y: 0.0,
-                z: 0.0,
+                x: 1.1,
+                y: 0.6210451,
+                z: 0.9,
             },
         },
         Example {
-            path: "../examples/stylised_sword.bjk",
+            path: "../examples/static-sword.bjk",
             vertices: 284,
             halfedges: 988,
             faces: 228,
             bounding_box_center: Vec3 {
-                x: 0.0,
-                y: 0.0,
-                z: 0.0,
+                x: 0.020206064,
+                y: 0.14655268,
+                z: 0.074326545,
             },
             bounding_box_size: Vec3 {
-                x: 0.0,
-                y: 0.0,
-                z: 0.0,
+                x: 1.1485293,
+                y: 2.532574,
+                z: 1.3417027,
             },
         },
         Example {

--- a/blackjack_engine/src/engine_tests.rs
+++ b/blackjack_engine/src/engine_tests.rs
@@ -122,9 +122,9 @@ pub fn test_examples_folder() {
                 z: 0.0,
             },
             bounding_box_size: Vec3 {
-                x: 6.9999986,
+                x: 7.0,
                 y: 3.9965458,
-                z: 6.9999986,
+                z: 7.0,
             },
         },
     ];

--- a/blackjack_engine/src/engine_tests.rs
+++ b/blackjack_engine/src/engine_tests.rs
@@ -37,7 +37,8 @@ struct Example {
     vertices: usize,
     halfedges: usize,
     faces: usize,
-    bounding_box: primitives::Box, // TODO: enable std::marker::Copy trait on primitives::Box
+    bounding_box_center: Vec3,
+    bounding_box_size: Vec3,
 }
 
 fn run_example(example: &Example, rt: &LuaRuntime) -> ProgramResult {
@@ -67,40 +68,64 @@ pub fn test_examples_folder() {
             vertices: 8,
             halfedges: 24,
             faces: 6,
-            bounding_box: primitives::Box::build(
-                Vec3 { x: 0, y: 0, z: 0 }, // TODO: fix center and size
-                Vec3 { x: 0, y: 0, z: 0 },
-            ),
+            bounding_box_center: Vec3 {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            bounding_box_size: Vec3 {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
         },
         Example {
             path: "../examples/tp_cutter.bjk",
             vertices: 184,
             halfedges: 680,
             faces: 170,
-            bounding_box: primitives::Box::build(
-                Vec3 { x: 0, y: 0, z: 0 }, // TODO: fix center and size
-                Vec3 { x: 0, y: 0, z: 0 },
-            ),
+            bounding_box_center: Vec3 {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            bounding_box_size: Vec3 {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
         },
         Example {
             path: "../examples/stylised_sword.bjk",
             vertices: 284,
             halfedges: 988,
             faces: 228,
-            bounding_box: primitives::Box::build(
-                Vec3 { x: 0, y: 0, z: 0 }, // TODO: fix center and size
-                Vec3 { x: 0, y: 0, z: 0 },
-            ),
+            bounding_box_center: Vec3 {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            bounding_box_size: Vec3 {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
         },
         Example {
             path: "../examples/extrude-quad-along-helix.bjk",
             vertices: 148,
             halfedges: 584,
             faces: 144,
-            bounding_box: primitives::Box::build(
-                Vec3 { x: 0, y: 0, z: 0 }, // TODO: fix center and size
-                Vec3 { x: 0, y: 0, z: 0 },
-            ),
+            bounding_box_center: Vec3 {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            bounding_box_size: Vec3 {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
         },
     ];
 
@@ -111,7 +136,9 @@ pub fn test_examples_folder() {
             assert_eq!(h.read_connectivity().num_vertices(), example.vertices);
             assert_eq!(h.read_connectivity().num_halfedges(), example.halfedges);
             assert_eq!(h.read_connectivity().num_faces(), example.faces);
-            assert_eq!(h.bounding_box(), example.bounding_box);
+            let (got_center, got_size) = h.bounding_box();
+            assert_eq!(got_center, example.bounding_box_center);
+            assert_eq!(got_size, example.bounding_box_size);
         } else {
             panic!("Expected a mesh")
         }

--- a/blackjack_engine/src/lua_engine/node_library.lua
+++ b/blackjack_engine/src/lua_engine/node_library.lua
@@ -12,11 +12,14 @@ function NodeLibrary:addNodes(nodes)
     assert(type(nodes) == "table")
 
     for k, v in pairs(nodes) do
-        if self.nodes[k] then
-            io.stderr:write("[Engine] Redefinition for node "..k.."\n")
-        else
-            io.stderr:write("[Engine] Loading new node definition for "..k.."\n")
-        end
+	-- mlua does not provide io.stderr, and this module can't be
+	-- used to directly generate code if it prints to stdout, so
+	-- the following needs to be commented out until mlua supports io.stderr:
+        -- if self.nodes[k] then
+        --     io.stderr:write("[Engine] Redefinition for node "..k.."\n")
+        -- else
+        --     io.stderr:write("[Engine] Loading new node definition for "..k.."\n")
+        -- end
         self.nodes[k] = v
     end
 end

--- a/blackjack_engine/src/lua_engine/node_library.lua
+++ b/blackjack_engine/src/lua_engine/node_library.lua
@@ -13,9 +13,9 @@ function NodeLibrary:addNodes(nodes)
 
     for k, v in pairs(nodes) do
         if self.nodes[k] then
-            print("[Engine] Redefinition for node "..k)
+            io.stderr:write("[Engine] Redefinition for node "..k.."\n")
         else
-            print("[Engine] Loading new node definition for "..k)
+            io.stderr:write("[Engine] Loading new node definition for "..k.."\n")
         end
         self.nodes[k] = v
     end

--- a/blackjack_engine/src/mesh/halfedge.rs
+++ b/blackjack_engine/src/mesh/halfedge.rs
@@ -530,8 +530,34 @@ impl HalfEdgeMesh {
     }
 
     pub fn bounding_box(&self) -> (Vec3, Vec3) {
-        let center = Vec3::new(0., 0., 0.); // TODO: calculate center and size from vertices
-        let size = Vec3::new(0., 0., 0.);
+        let mut min = Vec3::new(f32::MAX, f32::MAX, f32::MAX);
+        let mut max = Vec3::new(f32::MIN, f32::MIN, f32::MIN);
+        for v in self.read_positions().iter() {
+            if v.1.x < min.x {
+                min.x = v.1.x
+            }
+            if v.1.y < min.y {
+                min.y = v.1.y
+            }
+            if v.1.z < min.z {
+                min.z = v.1.z
+            }
+            if v.1.x > max.x {
+                max.x = v.1.x
+            }
+            if v.1.y > max.y {
+                max.y = v.1.y
+            }
+            if v.1.z > max.z {
+                max.z = v.1.z
+            }
+        }
+        let center = Vec3::new(
+            (min.x + max.x) / 2.0,
+            (min.y + max.y) / 2.0,
+            (min.z + max.z) / 2.0,
+        );
+        let size = Vec3::new(max.x - min.x, max.y - min.y, max.z - min.z);
         (center, size)
     }
 

--- a/blackjack_engine/src/mesh/halfedge.rs
+++ b/blackjack_engine/src/mesh/halfedge.rs
@@ -529,6 +529,12 @@ impl HalfEdgeMesh {
         }
     }
 
+    pub fn bounding_box(&self) -> Result<HalfEdgeMesh> {
+        let center = Vec3::new(0., 0., 0.); // TODO: calculate center and size from vertices
+        let size = Vec3::new(0., 0., 0.);
+        primitives::Box::build(center, size)
+    }
+
     pub fn read_connectivity(&self) -> BorrowedRef<'_, MeshConnectivity> {
         self.connectivity.borrow()
     }

--- a/blackjack_engine/src/mesh/halfedge.rs
+++ b/blackjack_engine/src/mesh/halfedge.rs
@@ -529,10 +529,10 @@ impl HalfEdgeMesh {
         }
     }
 
-    pub fn bounding_box(&self) -> Result<HalfEdgeMesh> {
+    pub fn bounding_box(&self) -> (Vec3, Vec3) {
         let center = Vec3::new(0., 0., 0.); // TODO: calculate center and size from vertices
         let size = Vec3::new(0., 0., 0.);
-        primitives::Box::build(center, size)
+        (center, size)
     }
 
     pub fn read_connectivity(&self) -> BorrowedRef<'_, MeshConnectivity> {

--- a/blackjack_engine/src/mesh/halfedge/edit_ops.rs
+++ b/blackjack_engine/src/mesh/halfedge/edit_ops.rs
@@ -1560,7 +1560,7 @@ pub fn extrude_along_curve(
     let mut positions = vec![];
 
     let first_vertex_id = backbone_conn.iter_vertices().next().unwrap().0;
-    println!("first_vertex_id={:?}", first_vertex_id);
+    // println!("first_vertex_id={:?}", first_vertex_id);
     for (v, _) in backbone_conn.iter_vertices() {
         let scale = if let Ok(ref size) = backbone_size {
             Vec3::splat(size[v])
@@ -1574,10 +1574,10 @@ pub fn extrude_along_curve(
             let normal = normal_ch[v];
             let tangent = tangent_ch[v];
             let cotangent = normal.cross(tangent);
-            println!(
-                "v={:?}, normal={:?}, tangent={:?}, cotangent={:?}",
-                v, normal, tangent, cotangent
-            );
+            // println!(
+            //     "v={:?}, normal={:?}, tangent={:?}, cotangent={:?}",
+            //     v, normal, tangent, cotangent
+            // );
             let (_, rotate, _) = glam::Affine3A::from_cols(
                 cotangent.into(),
                 normal.into(),
@@ -1590,13 +1590,19 @@ pub fn extrude_along_curve(
         } else {
             glam::Quat::IDENTITY
         };
-        println!("v={:?}, rotate={:?}", v, rotate);
+        // println!("v={:?}, rotate={:?}", v, rotate);
 
         for vc in csect_chain.iter_cpy() {
             let pos = csect_pos[vc] - backbone_pos[first_vertex_id];
             // let rot = Quat::from_euler(glam::EulerRot::XYZ, rotate.x, rotate.y, rotate.z);
-            println!("v={:?}, pos={:?}, pos*scale={:?}, rotate*(pos*scale)={:?} backbone_pos={:?}, final={:?}",
-            v, pos, pos*scale, rotate*(pos*scale), backbone_pos[v], rotate * (pos * scale) + backbone_pos[v]);
+            // println!(
+            //     "v={:?}, pos={:?}, rotate*(pos*scale)={:?} backbone_pos={:?}, final={:?}",
+            //     v,
+            //     pos,
+            //     rotate * (pos * scale),
+            //     backbone_pos[v],
+            //     rotate * (pos * scale) + backbone_pos[v]
+            // );
             positions.push(rotate * (pos * scale) + backbone_pos[v]);
         }
     }

--- a/blackjack_engine/src/mesh/halfedge/edit_ops.rs
+++ b/blackjack_engine/src/mesh/halfedge/edit_ops.rs
@@ -1559,7 +1559,6 @@ pub fn extrude_along_curve(
 
     let mut positions = vec![];
 
-    let first_vertex_id = backbone_conn.iter_vertices().next().unwrap().0;
     for (v, _) in backbone_conn.iter_vertices() {
         let scale = if let Ok(ref size) = backbone_size {
             Vec3::splat(size[v])
@@ -1580,14 +1579,15 @@ pub fn extrude_along_curve(
                 glam::Vec3A::ZERO,
             )
             .to_scale_rotation_translation();
-            rotate
+            rotate.to_euler(glam::EulerRot::XYZ).into()
         } else {
-            glam::Quat::IDENTITY
+            Vec3::ZERO
         };
 
         for vc in csect_chain.iter_cpy() {
-            let pos = csect_pos[vc] - backbone_pos[first_vertex_id];
-            positions.push(rotate * (pos * scale) + backbone_pos[v]);
+            let pos = csect_pos[vc];
+            let rot = Quat::from_euler(glam::EulerRot::XYZ, rotate.x, rotate.y, rotate.z);
+            positions.push(rot * (pos * scale) + backbone_pos[v]);
         }
     }
 

--- a/blackjack_engine/src/mesh/halfedge/edit_ops.rs
+++ b/blackjack_engine/src/mesh/halfedge/edit_ops.rs
@@ -1560,7 +1560,6 @@ pub fn extrude_along_curve(
     let mut positions = vec![];
 
     let first_vertex_id = backbone_conn.iter_vertices().next().unwrap().0;
-    // println!("first_vertex_id={:?}", first_vertex_id);
     for (v, _) in backbone_conn.iter_vertices() {
         let scale = if let Ok(ref size) = backbone_size {
             Vec3::splat(size[v])
@@ -1574,10 +1573,6 @@ pub fn extrude_along_curve(
             let normal = normal_ch[v];
             let tangent = tangent_ch[v];
             let cotangent = normal.cross(tangent);
-            // println!(
-            //     "v={:?}, normal={:?}, tangent={:?}, cotangent={:?}",
-            //     v, normal, tangent, cotangent
-            // );
             let (_, rotate, _) = glam::Affine3A::from_cols(
                 cotangent.into(),
                 normal.into(),
@@ -1585,24 +1580,13 @@ pub fn extrude_along_curve(
                 glam::Vec3A::ZERO,
             )
             .to_scale_rotation_translation();
-            // rotate.to_euler(glam::EulerRot::XYZ).into()
             rotate
         } else {
             glam::Quat::IDENTITY
         };
-        // println!("v={:?}, rotate={:?}", v, rotate);
 
         for vc in csect_chain.iter_cpy() {
             let pos = csect_pos[vc] - backbone_pos[first_vertex_id];
-            // let rot = Quat::from_euler(glam::EulerRot::XYZ, rotate.x, rotate.y, rotate.z);
-            // println!(
-            //     "v={:?}, pos={:?}, rotate*(pos*scale)={:?} backbone_pos={:?}, final={:?}",
-            //     v,
-            //     pos,
-            //     rotate * (pos * scale),
-            //     backbone_pos[v],
-            //     rotate * (pos * scale) + backbone_pos[v]
-            // );
             positions.push(rotate * (pos * scale) + backbone_pos[v]);
         }
     }

--- a/blackjack_engine/src/mesh/halfedge/primitives.rs
+++ b/blackjack_engine/src/mesh/halfedge/primitives.rs
@@ -590,6 +590,23 @@ mod lua_api {
         Line::build_from_points(LVec3::cast_vector(points))
     }
 
+    /// Creates a polyline from a given sequence of `points` with normals.
+    #[lua(under = "Primitives")]
+    fn line_with_normals(
+        points: Vec<LVec3>,
+        normals: Vec<LVec3>,
+        tangents: Vec<LVec3>,
+        segments: u32,
+    ) -> Result<HalfEdgeMesh> {
+        let pts = LVec3::cast_vector(points);
+        let nrms = LVec3::cast_vector(normals);
+        let tgts = LVec3::cast_vector(tangents);
+        let position = |i: u32| pts[i as usize];
+        let normal = |i: u32| nrms[i as usize];
+        let tangent = |i: u32| tgts[i as usize];
+        Line::build_with_normals(&position, &normal, &tangent, segments)
+    }
+
     /// Creates a catenary curve, the curve followed by a chain or rope hanging between two points,
     /// between `start` and `end` split into a number of `segments`. `sag` adjusts how much the curve sags,
     /// higher values make the curve hang lower, lower values make it closer to a straight line.

--- a/blackjack_lua/run/core_nodes.lua
+++ b/blackjack_lua/run/core_nodes.lua
@@ -357,6 +357,23 @@ local edit_ops = {
             return { out_mesh = out_mesh }
         end,
     },
+    ExtrudeFacesWithCaps = {
+        label = "Extrude Faces With Caps",
+        inputs = {
+            P.mesh("in_mesh"),
+            P.selection("faces"),
+            P.scalar("amount", { default = 0.0 }),
+        },
+        outputs = {
+            P.mesh("out_mesh"),
+        },
+        returns = "out_mesh",
+        op = function(inputs)
+            local out_mesh = inputs.in_mesh:clone()
+            Ops.extrude_with_caps(inputs.faces, inputs.amount, out_mesh)
+            return { out_mesh = out_mesh }
+        end,
+    },
     CollapseEdge = {
         label = "Collapse Edges",
         inputs = {

--- a/blackjack_lua/run/helix.lua
+++ b/blackjack_lua/run/helix.lua
@@ -9,9 +9,9 @@ NodeLibrary:addNodes(
             op = function(inputs)
                 local points = {}
                 local max_angle = inputs.turns * 2.0 * math.pi
-                local num_steps = math.ceil(inputs.turns * inputs.segments)
+                local total_segments = math.ceil(inputs.turns * inputs.segments)
 
-                if num_steps < 1 then
+                if total_segments < 1 then
                     return {
                         out_mesh = Primitives.line_from_points(points)
                     }
@@ -19,11 +19,11 @@ NodeLibrary:addNodes(
 
                 local normals = {}
                 local tangents = {}
-                local angle_delta = max_angle / num_steps
-                local delta_y = inputs.size.y * inputs.turns / num_steps
+                local angle_delta = max_angle / total_segments
+                local delta_y = inputs.size.y * inputs.turns / total_segments
                 local direction = inputs.direction == "Clockwise" and -1 or 1
                 local start_angle = math.pi * inputs.start_angle / 180
-                for i = 0, num_steps do
+                for i = 0, total_segments do
                     local angle = direction * (start_angle + i * angle_delta)
                     local cos_angle = math.cos(angle)
                     local sin_angle = math.sin(angle)
@@ -44,7 +44,7 @@ NodeLibrary:addNodes(
                     table.insert(normals, normal)
                 end
                 return {
-                    out_mesh = Primitives.line_with_normals(points, normals, tangents, num_steps)
+                    out_mesh = Primitives.line_with_normals(points, normals, tangents, total_segments)
                 }
             end,
             inputs = {

--- a/blackjack_lua/run/helix.lua
+++ b/blackjack_lua/run/helix.lua
@@ -50,7 +50,7 @@ NodeLibrary:addNodes(
             inputs = {
                 P.v3("pos", vector(0, 0, 0)),
                 P.v3("size", vector(1, 1, 1)),
-                P.scalar("start_angle", {default = 0, min = 0, soft_max = 360}),
+                P.scalar("start_angle", {default = 0, soft_max = 360}),
                 P.scalar("turns", {default = 1, min = 0, soft_max = 10}),
                 P.scalar_int("segments", {default = 36, min = 1, soft_max = 360}),
                 P.enum("direction", {"Clockwise", "Counter-Clockwise"}, 0)

--- a/blackjack_lua/run/helix.lua
+++ b/blackjack_lua/run/helix.lua
@@ -1,5 +1,6 @@
 local P = require("params")
 local NodeLibrary = require("node_library")
+local V = require("vector_math")
 
 NodeLibrary:addNodes({
     Helix = {
@@ -29,11 +30,13 @@ NodeLibrary:addNodes({
                 local x = inputs.pos.x + inputs.size.x * cos_angle
                 local z = inputs.pos.z + inputs.size.z * sin_angle
                 local y = inputs.pos.y + i * delta_y -- y is "up"
-                table.insert(points, vector(x, y, z))
+                local point = vector(x, y, z)
+                table.insert(points, point)
                 local tx = -direction * sin_angle
                 local tz = direction * cos_angle
-                local ty = 0.0
-                table.insert(tangents, vector(tx, ty, tz))
+                local ty = delta_y
+                local tangent = V.normalize(vector(tx, ty, tz))
+                table.insert(tangents, tangent)
                 -- local next_angle = direction * (start_angle + (i + 1) * angle_delta)
                 -- local nx = inputs.size.x * (math.cos(next_angle) - cos_angle)
                 -- local nz = inputs.size.z * (math.sin(next_angle) - sin_angle)
@@ -41,7 +44,10 @@ NodeLibrary:addNodes({
                 local nx = 0.0
                 local nz = 0.0
                 local ny = 1.0
+                -- local normal = V.normalize(vector(nx, ny, nz))
+                -- table.insert(normals, normal)
                 table.insert(normals, vector(nx, ny, nz))
+                -- table.insert(normals, V.cross(point, tangent))
             end
             return {
                 out_mesh = Primitives.line_with_normals(points, normals, tangents, num_steps)

--- a/blackjack_lua/run/helix.lua
+++ b/blackjack_lua/run/helix.lua
@@ -37,17 +37,11 @@ NodeLibrary:addNodes({
                 local ty = delta_y
                 local tangent = V.normalize(vector(tx, ty, tz))
                 table.insert(tangents, tangent)
-                -- local next_angle = direction * (start_angle + (i + 1) * angle_delta)
-                -- local nx = inputs.size.x * (math.cos(next_angle) - cos_angle)
-                -- local nz = inputs.size.z * (math.sin(next_angle) - sin_angle)
-                -- local ny = delta_y
-                local nx = 0.0
-                local nz = 0.0
-                local ny = 1.0
-                -- local normal = V.normalize(vector(nx, ny, nz))
-                -- table.insert(normals, normal)
-                table.insert(normals, vector(nx, ny, nz))
-                -- table.insert(normals, V.cross(point, tangent))
+                local nx = cos_angle
+                local nz = sin_angle
+                local ny = 0.0
+                local normal = V.normalize(V.cross(vector(nx, ny, nz), tangent))
+                table.insert(normals, normal)
             end
             return {
                 out_mesh = Primitives.line_with_normals(points, normals, tangents, num_steps)

--- a/blackjack_lua/run/helix.lua
+++ b/blackjack_lua/run/helix.lua
@@ -5,39 +5,56 @@ NodeLibrary:addNodes({
     Helix = {
         label = "Helix",
         op = function(inputs)
-	    local points = {}
-	    -- Generate the points
-	    local max_angle = inputs.turns * 2.0 * math.pi
-	    local num_steps = math.ceil(inputs.turns * inputs.segments)
+            local points = {}
+            -- Generate the points
+            local max_angle = inputs.turns * 2.0 * math.pi
+            local num_steps = math.ceil(inputs.turns * inputs.segments)
 
-	    if num_steps < 1 then
-                return { out_mesh = Primitives.line_from_points(points) }
-	    end
+            if num_steps < 1 then
+                return {
+                    out_mesh = Primitives.line_from_points(points)
+                }
+            end
 
-	    local angle_delta = max_angle / num_steps
-	    local delta_y = inputs.size.y * inputs.turns / num_steps
-	    local direction = inputs.direction == "Clockwise" and -1 or 1
-	    local start_angle = math.pi * inputs.start_angle / 180
-	    for i = 0, num_steps do
-	    	local angle = direction * (start_angle + i * angle_delta)
-	        local x = inputs.pos.x + inputs.size.x * math.cos(angle)
-	        local z = inputs.pos.z + inputs.size.z * math.sin(angle)
-	        local y = inputs.pos.y + i * delta_y
-		table.insert(points, vector(x, y, z))
-	    end
-            return { out_mesh = Primitives.line_from_points(points) }
+            local normals = {}
+            local tangents = {}
+            local angle_delta = max_angle / num_steps
+            local delta_y = inputs.size.y * inputs.turns / num_steps
+            local direction = inputs.direction == "Clockwise" and -1 or 1
+            local start_angle = math.pi * inputs.start_angle / 180
+            for i = 0, num_steps do
+                local angle = direction * (start_angle + i * angle_delta)
+                local x = inputs.pos.x + inputs.size.x * math.cos(angle)
+                local z = inputs.pos.z + inputs.size.z * math.sin(angle)
+                local y = inputs.pos.y + i * delta_y -- y is "up"
+                local nx = 0.0
+                local nz = 0.0
+                local ny = 1.0
+                local tx = math.sin(angle)
+                local tz = math.cos(angle)
+                local ty = 0.0
+                table.insert(points, vector(x, y, z))
+                table.insert(normals, vector(nx, ny, nz))
+                table.insert(tangents, vector(tx, ty, tz))
+            end
+            return {
+                out_mesh = Primitives.line_with_normals(points, normals, tangents, num_steps)
+            }
         end,
-        inputs = {
-            P.v3("pos", vector(0, 0, 0)),
-            P.v3("size", vector(1, 1, 1)),
-            P.scalar("start_angle", { default = 0, min = 0, soft_max = 360 }),
-            P.scalar("turns", { default = 1, min = 0, soft_max = 10 }),
-            P.scalar_int("segments", { default = 36, min = 1, soft_max = 360 }),
-	    P.enum("direction", { "Clockwise", "Counter-Clockwise"}, 0),
-        },
-        outputs = {
-            P.mesh("out_mesh"),
-        },
-        returns = "out_mesh",
-    },
+        inputs = {P.v3("pos", vector(0, 0, 0)), P.v3("size", vector(1, 1, 1)), P.scalar("start_angle", {
+            default = 0,
+            min = 0,
+            soft_max = 360
+        }), P.scalar("turns", {
+            default = 1,
+            min = 0,
+            soft_max = 10
+        }), P.scalar_int("segments", {
+            default = 36,
+            min = 1,
+            soft_max = 360
+        }), P.enum("direction", {"Clockwise", "Counter-Clockwise"}, 0)},
+        outputs = {P.mesh("out_mesh")},
+        returns = "out_mesh"
+    }
 })

--- a/blackjack_lua/run/helix.lua
+++ b/blackjack_lua/run/helix.lua
@@ -34,7 +34,7 @@ NodeLibrary:addNodes(
                     table.insert(points, point)
                     local tx = -direction * sin_angle
                     local tz = direction * cos_angle
-                    local ty = delta_y
+                    local ty = 0.0
                     local tangent = V.normalize(vector(tx, ty, tz))
                     table.insert(tangents, tangent)
                     local nx = cos_angle

--- a/blackjack_lua/run/helix.lua
+++ b/blackjack_lua/run/helix.lua
@@ -2,65 +2,61 @@ local P = require("params")
 local NodeLibrary = require("node_library")
 local V = require("vector_math")
 
-NodeLibrary:addNodes({
-    Helix = {
-        label = "Helix",
-        op = function(inputs)
-            local points = {}
-            -- Generate the points
-            local max_angle = inputs.turns * 2.0 * math.pi
-            local num_steps = math.ceil(inputs.turns * inputs.segments)
+NodeLibrary:addNodes(
+    {
+        Helix = {
+            label = "Helix",
+            op = function(inputs)
+                local points = {}
+                local max_angle = inputs.turns * 2.0 * math.pi
+                local num_steps = math.ceil(inputs.turns * inputs.segments)
 
-            if num_steps < 1 then
+                if num_steps < 1 then
+                    return {
+                        out_mesh = Primitives.line_from_points(points)
+                    }
+                end
+
+                local normals = {}
+                local tangents = {}
+                local angle_delta = max_angle / num_steps
+                local delta_y = inputs.size.y * inputs.turns / num_steps
+                local direction = inputs.direction == "Clockwise" and -1 or 1
+                local start_angle = math.pi * inputs.start_angle / 180
+                for i = 0, num_steps do
+                    local angle = direction * (start_angle + i * angle_delta)
+                    local cos_angle = math.cos(angle)
+                    local sin_angle = math.sin(angle)
+                    local x = inputs.pos.x + inputs.size.x * cos_angle
+                    local z = inputs.pos.z + inputs.size.z * sin_angle
+                    local y = inputs.pos.y + i * delta_y -- y is "up"
+                    local point = vector(x, y, z)
+                    table.insert(points, point)
+                    local tx = -direction * sin_angle
+                    local tz = direction * cos_angle
+                    local ty = delta_y
+                    local tangent = V.normalize(vector(tx, ty, tz))
+                    table.insert(tangents, tangent)
+                    local nx = cos_angle
+                    local nz = sin_angle
+                    local ny = 0.0
+                    local normal = V.normalize(V.cross(vector(nx, ny, nz), tangent))
+                    table.insert(normals, normal)
+                end
                 return {
-                    out_mesh = Primitives.line_from_points(points)
+                    out_mesh = Primitives.line_with_normals(points, normals, tangents, num_steps)
                 }
-            end
-
-            local normals = {}
-            local tangents = {}
-            local angle_delta = max_angle / num_steps
-            local delta_y = inputs.size.y * inputs.turns / num_steps
-            local direction = inputs.direction == "Clockwise" and -1 or 1
-            local start_angle = math.pi * inputs.start_angle / 180
-            for i = 0, num_steps do
-                local angle = direction * (start_angle + i * angle_delta)
-                local cos_angle = math.cos(angle)
-                local sin_angle = math.sin(angle)
-                local x = inputs.pos.x + inputs.size.x * cos_angle
-                local z = inputs.pos.z + inputs.size.z * sin_angle
-                local y = inputs.pos.y + i * delta_y -- y is "up"
-                local point = vector(x, y, z)
-                table.insert(points, point)
-                local tx = -direction * sin_angle
-                local tz = direction * cos_angle
-                local ty = delta_y
-                local tangent = V.normalize(vector(tx, ty, tz))
-                table.insert(tangents, tangent)
-                local nx = cos_angle
-                local nz = sin_angle
-                local ny = 0.0
-                local normal = V.normalize(V.cross(vector(nx, ny, nz), tangent))
-                table.insert(normals, normal)
-            end
-            return {
-                out_mesh = Primitives.line_with_normals(points, normals, tangents, num_steps)
-            }
-        end,
-        inputs = {P.v3("pos", vector(0, 0, 0)), P.v3("size", vector(1, 1, 1)), P.scalar("start_angle", {
-            default = 0,
-            min = 0,
-            soft_max = 360
-        }), P.scalar("turns", {
-            default = 1,
-            min = 0,
-            soft_max = 10
-        }), P.scalar_int("segments", {
-            default = 36,
-            min = 1,
-            soft_max = 360
-        }), P.enum("direction", {"Clockwise", "Counter-Clockwise"}, 0)},
-        outputs = {P.mesh("out_mesh")},
-        returns = "out_mesh"
+            end,
+            inputs = {
+                P.v3("pos", vector(0, 0, 0)),
+                P.v3("size", vector(1, 1, 1)),
+                P.scalar("start_angle", {default = 0, min = 0, soft_max = 360}),
+                P.scalar("turns", {default = 1, min = 0, soft_max = 10}),
+                P.scalar_int("segments", {default = 36, min = 1, soft_max = 360}),
+                P.enum("direction", {"Clockwise", "Counter-Clockwise"}, 0)
+            },
+            outputs = {P.mesh("out_mesh")},
+            returns = "out_mesh"
+        }
     }
-})
+)

--- a/blackjack_lua/run/helix.lua
+++ b/blackjack_lua/run/helix.lua
@@ -1,0 +1,43 @@
+local P = require("params")
+local NodeLibrary = require("node_library")
+
+NodeLibrary:addNodes({
+    Helix = {
+        label = "Helix",
+        op = function(inputs)
+	    local points = {}
+	    -- Generate the points
+	    local max_angle = inputs.turns * 2.0 * math.pi
+	    local num_steps = math.ceil(inputs.turns * inputs.segments)
+
+	    if num_steps < 1 then
+                return { out_mesh = Primitives.line_from_points(points) }
+	    end
+
+	    local angle_delta = max_angle / num_steps
+	    local delta_y = inputs.size.y * inputs.turns / num_steps
+	    local direction = inputs.direction == "Clockwise" and -1 or 1
+	    local start_angle = math.pi * inputs.start_angle / 180
+	    for i = 0, num_steps do
+	    	local angle = direction * (start_angle + i * angle_delta)
+	        local x = inputs.pos.x + inputs.size.x * math.cos(angle)
+	        local z = inputs.pos.z + inputs.size.z * math.sin(angle)
+	        local y = inputs.pos.y + i * delta_y
+		table.insert(points, vector(x, y, z))
+	    end
+            return { out_mesh = Primitives.line_from_points(points) }
+        end,
+        inputs = {
+            P.v3("pos", vector(0, 0, 0)),
+            P.v3("size", vector(1, 1, 1)),
+            P.scalar("start_angle", { default = 0, min = 0, soft_max = 360 }),
+            P.scalar("turns", { default = 1, min = 0, soft_max = 10 }),
+            P.scalar_int("segments", { default = 36, min = 1, soft_max = 360 }),
+	    P.enum("direction", { "Clockwise", "Counter-Clockwise"}, 0),
+        },
+        outputs = {
+            P.mesh("out_mesh"),
+        },
+        returns = "out_mesh",
+    },
+})

--- a/blackjack_lua/run/helix.lua
+++ b/blackjack_lua/run/helix.lua
@@ -24,18 +24,24 @@ NodeLibrary:addNodes({
             local start_angle = math.pi * inputs.start_angle / 180
             for i = 0, num_steps do
                 local angle = direction * (start_angle + i * angle_delta)
-                local x = inputs.pos.x + inputs.size.x * math.cos(angle)
-                local z = inputs.pos.z + inputs.size.z * math.sin(angle)
+                local cos_angle = math.cos(angle)
+                local sin_angle = math.sin(angle)
+                local x = inputs.pos.x + inputs.size.x * cos_angle
+                local z = inputs.pos.z + inputs.size.z * sin_angle
                 local y = inputs.pos.y + i * delta_y -- y is "up"
+                table.insert(points, vector(x, y, z))
+                local tx = -direction * sin_angle
+                local tz = direction * cos_angle
+                local ty = 0.0
+                table.insert(tangents, vector(tx, ty, tz))
+                -- local next_angle = direction * (start_angle + (i + 1) * angle_delta)
+                -- local nx = inputs.size.x * (math.cos(next_angle) - cos_angle)
+                -- local nz = inputs.size.z * (math.sin(next_angle) - sin_angle)
+                -- local ny = delta_y
                 local nx = 0.0
                 local nz = 0.0
                 local ny = 1.0
-                local tx = math.sin(angle)
-                local tz = math.cos(angle)
-                local ty = 0.0
-                table.insert(points, vector(x, y, z))
                 table.insert(normals, vector(nx, ny, nz))
-                table.insert(tangents, vector(tx, ty, tz))
             end
             return {
                 out_mesh = Primitives.line_with_normals(points, normals, tangents, num_steps)

--- a/examples/extrude-quad-along-helix.bjk
+++ b/examples/extrude-quad-along-helix.bjk
@@ -1,0 +1,222 @@
+// BLACKJACK_VERSION_HEADER 0 1 0
+(
+    nodes: [
+        (
+            op_name: "MakeQuad",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "center",
+                    data_type: "BJK_VECTOR",
+                    kind: Conection(
+                        node_idx: 1,
+                        param_name: "point",
+                    ),
+                ),
+                (
+                    name: "normal",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "right",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "size",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "Point",
+            return_value: None,
+            inputs: [
+                (
+                    name: "point",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "point",
+                    data_type: "BJK_VECTOR",
+                ),
+            ],
+        ),
+        (
+            op_name: "Helix",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "pos",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "size",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "start_angle",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "turns",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "segments",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "direction",
+                    data_type: "BJK_STRING",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "ExtrudeAlongCurve",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "backbone",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 2,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "cross_section",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 0,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "flip",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+    ],
+    default_node: Some(3),
+    ui_data: Some((
+        node_positions: [
+            (1067.2892, 238.28516),
+            (630.3985, 112.47682),
+            (1075.0774, 478.61154),
+            (1625.3439, 371.60907),
+        ],
+        node_order: [
+            1,
+            0,
+            2,
+            3,
+        ],
+        pan: (-18.812515, -136.28624),
+        zoom: 0.96917236,
+        locked_gizmo_nodes: [
+            1,
+        ],
+    )),
+    external_parameters: Some((
+        param_values: {
+            (
+                node_idx: 1,
+                param_name: "point",
+            ): Vector((-2.9999993, 0.0, 0.0)),
+            (
+                node_idx: 0,
+                param_name: "right",
+            ): Vector((1.0, 0.0, 0.0)),
+            (
+                node_idx: 2,
+                param_name: "pos",
+            ): Vector((0.0, 0.0, 0.0)),
+            (
+                node_idx: 2,
+                param_name: "turns",
+            ): Scalar(1.0),
+            (
+                node_idx: 2,
+                param_name: "size",
+            ): Vector((3.0, 3.0, 3.0)),
+            (
+                node_idx: 2,
+                param_name: "start_angle",
+            ): Scalar(180.0),
+            (
+                node_idx: 0,
+                param_name: "normal",
+            ): Vector((0.0, 0.0, 1.0)),
+            (
+                node_idx: 3,
+                param_name: "flip",
+            ): Scalar(1.0),
+            (
+                node_idx: 0,
+                param_name: "size",
+            ): Vector((1.0, 1.0, 1.0)),
+            (
+                node_idx: 2,
+                param_name: "segments",
+            ): Scalar(36.0),
+            (
+                node_idx: 2,
+                param_name: "direction",
+            ): String("Clockwise"),
+        },
+    )),
+)

--- a/examples/extrude-quad-along-helix.bjk
+++ b/examples/extrude-quad-along-helix.bjk
@@ -155,15 +155,15 @@
     ui_data: Some((
         node_positions: [
             (1067.2892, 238.28516),
-            (630.3985, 112.47682),
+            (698.7592, 203.22693),
             (1075.0774, 478.61154),
             (1625.3439, 371.60907),
         ],
         node_order: [
-            1,
             0,
             2,
             3,
+            1,
         ],
         pan: (-18.812515, -136.28624),
         zoom: 0.96917236,
@@ -174,33 +174,25 @@
     external_parameters: Some((
         param_values: {
             (
-                node_idx: 1,
-                param_name: "point",
-            ): Vector((-2.9999993, 0.0, 0.0)),
+                node_idx: 0,
+                param_name: "normal",
+            ): Vector((0.0, 0.0, 1.0)),
             (
                 node_idx: 0,
                 param_name: "right",
             ): Vector((1.0, 0.0, 0.0)),
             (
                 node_idx: 2,
-                param_name: "pos",
-            ): Vector((0.0, 0.0, 0.0)),
+                param_name: "direction",
+            ): String("Clockwise"),
             (
-                node_idx: 2,
-                param_name: "turns",
-            ): Scalar(1.0),
+                node_idx: 1,
+                param_name: "point",
+            ): Vector((0.0, 0.0, 0.0)),
             (
                 node_idx: 2,
                 param_name: "size",
             ): Vector((3.0, 3.0, 3.0)),
-            (
-                node_idx: 2,
-                param_name: "start_angle",
-            ): Scalar(180.0),
-            (
-                node_idx: 0,
-                param_name: "normal",
-            ): Vector((0.0, 0.0, 1.0)),
             (
                 node_idx: 3,
                 param_name: "flip",
@@ -211,12 +203,20 @@
             ): Vector((1.0, 1.0, 1.0)),
             (
                 node_idx: 2,
+                param_name: "turns",
+            ): Scalar(1.0),
+            (
+                node_idx: 2,
                 param_name: "segments",
             ): Scalar(36.0),
             (
                 node_idx: 2,
-                param_name: "direction",
-            ): String("Clockwise"),
+                param_name: "pos",
+            ): Vector((0.0, 0.0, 0.0)),
+            (
+                node_idx: 2,
+                param_name: "start_angle",
+            ): Scalar(180.0),
         },
     )),
 )

--- a/examples/static-sword.bjk
+++ b/examples/static-sword.bjk
@@ -1,0 +1,2273 @@
+// BLACKJACK_VERSION_HEADER 0 1 0
+(
+    nodes: [
+        (
+            op_name: "MakeBox",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "origin",
+                    data_type: "BJK_VECTOR",
+                    kind: Conection(
+                        node_idx: 46,
+                        param_name: "v",
+                    ),
+                ),
+                (
+                    name: "size",
+                    data_type: "BJK_VECTOR",
+                    kind: Conection(
+                        node_idx: 49,
+                        param_name: "v",
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "ExtrudeFaces",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "in_mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 0,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "faces",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "amount",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "EditGeometry",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 1,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "geometry",
+                    data_type: "BJK_STRING",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "selection",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "translate",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "rotate",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "scale",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "ExtrudeFaces",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "in_mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 2,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "faces",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "amount",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "EditGeometry",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 3,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "geometry",
+                    data_type: "BJK_STRING",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "selection",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "translate",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "rotate",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "scale",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MakeComment",
+            return_value: None,
+            inputs: [
+                (
+                    name: "comment",
+                    data_type: "BJK_STRING",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [],
+        ),
+        (
+            op_name: "MakeComment",
+            return_value: None,
+            inputs: [
+                (
+                    name: "comment",
+                    data_type: "BJK_STRING",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [],
+        ),
+        (
+            op_name: "MakeBox",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "origin",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "size",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MergeMeshes",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "mesh_a",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 4,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "mesh_b",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 12,
+                        param_name: "out_mesh",
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "ExtrudeFaces",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "in_mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 7,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "faces",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "amount",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "EditGeometry",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 9,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "geometry",
+                    data_type: "BJK_STRING",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "selection",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "translate",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "rotate",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "scale",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MakeBox",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "origin",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "size",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MergeMeshes",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "mesh_a",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 10,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "mesh_b",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 21,
+                        param_name: "out_mesh",
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "ExtrudeFaces",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "in_mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 11,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "faces",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "amount",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "EditGeometry",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 13,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "geometry",
+                    data_type: "BJK_STRING",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "selection",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "translate",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "rotate",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "scale",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "ExtrudeFaces",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "in_mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 14,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "faces",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "amount",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "SubdivideEdge",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "in_mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 15,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "interp",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "edges",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "divisions",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "CutFace",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "in_mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 16,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "a",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "b",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "CutFace",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "in_mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 17,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "a",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "b",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "CutFace",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "in_mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 18,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "a",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "b",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "CutFace",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "in_mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 19,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "a",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "b",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "EditGeometry",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 26,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "geometry",
+                    data_type: "BJK_STRING",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "selection",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "translate",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "rotate",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "scale",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "CutFace",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "in_mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 20,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "a",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "b",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "CutFace",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "in_mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 22,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "a",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "b",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MakeComment",
+            return_value: None,
+            inputs: [
+                (
+                    name: "comment",
+                    data_type: "BJK_STRING",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [],
+        ),
+        (
+            op_name: "CutFace",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "in_mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 23,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "a",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "b",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "CutFace",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "in_mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 25,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "a",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "b",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MakeCylinder",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "center",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "radius",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "height",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "num_vertices",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MergeMeshes",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "mesh_a",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 42,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "mesh_b",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 8,
+                        param_name: "out_mesh",
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MakeCylinder",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "center",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "radius",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "height",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "num_vertices",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MergeMeshes",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "mesh_a",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 29,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "mesh_b",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 27,
+                        param_name: "out_mesh",
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MakeUVSphere",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "center",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "radius",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "segments",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "rings",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "ExtrudeFaces",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "in_mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 31,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "faces",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "amount",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "Transform",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 32,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "translate",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "rotate",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "scale",
+                    data_type: "BJK_VECTOR",
+                    kind: Conection(
+                        node_idx: 35,
+                        param_name: "v",
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MergeMeshes",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "mesh_a",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 33,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "mesh_b",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 30,
+                        param_name: "out_mesh",
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MakeVector",
+            return_value: None,
+            inputs: [
+                (
+                    name: "x",
+                    data_type: "BJK_SCALAR",
+                    kind: Conection(
+                        node_idx: 36,
+                        param_name: "x",
+                    ),
+                ),
+                (
+                    name: "y",
+                    data_type: "BJK_SCALAR",
+                    kind: Conection(
+                        node_idx: 36,
+                        param_name: "x",
+                    ),
+                ),
+                (
+                    name: "z",
+                    data_type: "BJK_SCALAR",
+                    kind: Conection(
+                        node_idx: 36,
+                        param_name: "x",
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "v",
+                    data_type: "BJK_VECTOR",
+                ),
+            ],
+        ),
+        (
+            op_name: "MakeScalar",
+            return_value: None,
+            inputs: [
+                (
+                    name: "x",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "x",
+                    data_type: "BJK_SCALAR",
+                ),
+            ],
+        ),
+        (
+            op_name: "MakeCylinder",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "center",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "radius",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "height",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "num_vertices",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MergeMeshes",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "mesh_a",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 37,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "mesh_b",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 34,
+                        param_name: "out_mesh",
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MakeCylinder",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "center",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "radius",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "height",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "num_vertices",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MergeMeshes",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "mesh_a",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 39,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "mesh_b",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 38,
+                        param_name: "out_mesh",
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MakeCylinder",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "center",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "radius",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "height",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "num_vertices",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MergeMeshes",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "mesh_a",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 44,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "mesh_b",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 40,
+                        param_name: "out_mesh",
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "ExtrudeFaces",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "in_mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 41,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "faces",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "amount",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "EditGeometry",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 43,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "geometry",
+                    data_type: "BJK_STRING",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "selection",
+                    data_type: "BJK_SELECTION",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "translate",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "rotate",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "scale",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "Transform",
+            return_value: Some("out_mesh"),
+            inputs: [
+                (
+                    name: "mesh",
+                    data_type: "BJK_MESH",
+                    kind: Conection(
+                        node_idx: 28,
+                        param_name: "out_mesh",
+                    ),
+                ),
+                (
+                    name: "translate",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "rotate",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "scale",
+                    data_type: "BJK_VECTOR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out_mesh",
+                    data_type: "BJK_MESH",
+                ),
+            ],
+        ),
+        (
+            op_name: "MakeVector",
+            return_value: None,
+            inputs: [
+                (
+                    name: "x",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "y",
+                    data_type: "BJK_SCALAR",
+                    kind: Conection(
+                        node_idx: 48,
+                        param_name: "out",
+                    ),
+                ),
+                (
+                    name: "z",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "v",
+                    data_type: "BJK_VECTOR",
+                ),
+            ],
+        ),
+        (
+            op_name: "MakeScalar",
+            return_value: None,
+            inputs: [
+                (
+                    name: "x",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "x",
+                    data_type: "BJK_SCALAR",
+                ),
+            ],
+        ),
+        (
+            op_name: "ScalarMath",
+            return_value: None,
+            inputs: [
+                (
+                    name: "op",
+                    data_type: "BJK_STRING",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "x",
+                    data_type: "BJK_SCALAR",
+                    kind: Conection(
+                        node_idx: 47,
+                        param_name: "x",
+                    ),
+                ),
+                (
+                    name: "y",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "out",
+                    data_type: "BJK_SCALAR",
+                ),
+            ],
+        ),
+        (
+            op_name: "MakeVector",
+            return_value: None,
+            inputs: [
+                (
+                    name: "x",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+                (
+                    name: "y",
+                    data_type: "BJK_SCALAR",
+                    kind: Conection(
+                        node_idx: 47,
+                        param_name: "x",
+                    ),
+                ),
+                (
+                    name: "z",
+                    data_type: "BJK_SCALAR",
+                    kind: External(
+                        promoted: None,
+                    ),
+                ),
+            ],
+            outputs: [
+                (
+                    name: "v",
+                    data_type: "BJK_VECTOR",
+                ),
+            ],
+        ),
+    ],
+    default_node: Some(45),
+    ui_data: Some((
+        node_positions: [
+            (533.4789, 112.83618),
+            (776.2125, 105.59393),
+            (1009.2163, 102.537415),
+            (1313.7124, 116.99518),
+            (1555.7578, 109.85925),
+            (248.10004, -18.675285),
+            (655.481, -146.21912),
+            (424.87268, 501.68576),
+            (3098.311, 380.79996),
+            (715.84125, 510.87955),
+            (964.46216, 494.30542),
+            (443.40405, 795.9087),
+            (2890.2312, 644.0747),
+            (756.6077, 802.32434),
+            (997.1362, 807.7252),
+            (1329.4741, 839.24506),
+            (1616.1681, 837.136),
+            (1877.0343, 850.0377),
+            (1887.1317, 1011.9061),
+            (1882.4338, 1175.0071),
+            (1879.5739, 1339.7295),
+            (2479.6558, 900.6941),
+            (2129.8481, 849.81995),
+            (2130.716, 1002.72656),
+            (1615.3099, 1031.5776),
+            (2126.6077, 1163.2212),
+            (2129.1072, 1323.7083),
+            (2440.7258, 81.46901),
+            (5194.502, 193.77817),
+            (2444.0154, -119.07425),
+            (2938.942, 14.011826),
+            (2531.0332, -392.76718),
+            (2849.6665, -377.06317),
+            (3121.938, -316.6556),
+            (3453.4136, 28.008926),
+            (2945.703, -210.18877),
+            (2757.9312, -181.87688),
+            (3517.1553, -195.32259),
+            (3866.728, 20.93164),
+            (3531.7134, -401.42688),
+            (4058.0962, -125.38214),
+            (3869.6968, -594.5799),
+            (4826.781, -183.9884),
+            (4216.9434, -568.3672),
+            (4456.5776, -577.2402),
+            (5436.814, 158.36205),
+            (76.965485, 61.9924),
+            (-325.96014, 167.1039),
+            (-141.43307, 79.116974),
+            (232.61072, 211.81525),
+        ],
+        node_order: [
+            1,
+            2,
+            3,
+            4,
+            6,
+            7,
+            9,
+            10,
+            11,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            22,
+            24,
+            23,
+            25,
+            26,
+            21,
+            12,
+            8,
+            31,
+            32,
+            30,
+            34,
+            35,
+            36,
+            29,
+            33,
+            27,
+            38,
+            37,
+            40,
+            39,
+            41,
+            43,
+            44,
+            42,
+            28,
+            45,
+            47,
+            46,
+            48,
+            49,
+            0,
+            5,
+        ],
+        pan: (-4327.893, -64.75046),
+        zoom: 0.8140639,
+        locked_gizmo_nodes: [],
+    )),
+    external_parameters: Some((
+        param_values: {
+            (
+                node_idx: 29,
+                param_name: "center",
+            ): Vector((0.0, -0.60037494, 0.0)),
+            (
+                node_idx: 10,
+                param_name: "scale",
+            ): Vector((1.0, 0.42014277, 1.0)),
+            (
+                node_idx: 9,
+                param_name: "amount",
+            ): Scalar(0.4),
+            (
+                node_idx: 10,
+                param_name: "selection",
+            ): Selection("4,5"),
+            (
+                node_idx: 10,
+                param_name: "rotate",
+            ): Vector((-0.0, 0.0, -0.0)),
+            (
+                node_idx: 49,
+                param_name: "x",
+            ): Scalar(0.4),
+            (
+                node_idx: 39,
+                param_name: "height",
+            ): Scalar(0.10000002),
+            (
+                node_idx: 13,
+                param_name: "faces",
+            ): Selection("1"),
+            (
+                node_idx: 15,
+                param_name: "faces",
+            ): Selection("1"),
+            (
+                node_idx: 18,
+                param_name: "b",
+            ): Selection("10"),
+            (
+                node_idx: 10,
+                param_name: "geometry",
+            ): String("Face"),
+            (
+                node_idx: 31,
+                param_name: "segments",
+            ): Scalar(12.0),
+            (
+                node_idx: 21,
+                param_name: "geometry",
+            ): String("Face"),
+            (
+                node_idx: 29,
+                param_name: "num_vertices",
+            ): Scalar(12.0),
+            (
+                node_idx: 3,
+                param_name: "amount",
+            ): Scalar(0.1),
+            (
+                node_idx: 44,
+                param_name: "selection",
+            ): Selection("0"),
+            (
+                node_idx: 26,
+                param_name: "b",
+            ): Selection("32"),
+            (
+                node_idx: 4,
+                param_name: "scale",
+            ): Vector((0.2515632, 1.0, 0.4267174)),
+            (
+                node_idx: 49,
+                param_name: "z",
+            ): Scalar(0.05),
+            (
+                node_idx: 27,
+                param_name: "num_vertices",
+            ): Scalar(12.0),
+            (
+                node_idx: 37,
+                param_name: "num_vertices",
+            ): Scalar(12.0),
+            (
+                node_idx: 14,
+                param_name: "scale",
+            ): Vector((0.87455827, 1.0, 0.70387906)),
+            (
+                node_idx: 2,
+                param_name: "scale",
+            ): Vector((0.6839815, 0.9, 0.5999999)),
+            (
+                node_idx: 22,
+                param_name: "a",
+            ): Selection("29"),
+            (
+                node_idx: 21,
+                param_name: "rotate",
+            ): Vector((-0.0, 0.0, -0.0)),
+            (
+                node_idx: 27,
+                param_name: "height",
+            ): Scalar(0.10000002),
+            (
+                node_idx: 43,
+                param_name: "faces",
+            ): Selection("0"),
+            (
+                node_idx: 9,
+                param_name: "faces",
+            ): Selection("4,5"),
+            (
+                node_idx: 14,
+                param_name: "geometry",
+            ): String("Face"),
+            (
+                node_idx: 14,
+                param_name: "translate",
+            ): Vector((0.0, 0.0, 0.0)),
+            (
+                node_idx: 5,
+                param_name: "comment",
+            ): String("-- Blade --"),
+            (
+                node_idx: 14,
+                param_name: "rotate",
+            ): Vector((-0.0, 0.0, -0.0)),
+            (
+                node_idx: 16,
+                param_name: "interp",
+            ): Scalar(0.5),
+            (
+                node_idx: 2,
+                param_name: "rotate",
+            ): Vector((-0.0, 0.0, -0.0)),
+            (
+                node_idx: 41,
+                param_name: "center",
+            ): Vector((0.0, -1.1873153, 0.0)),
+            (
+                node_idx: 13,
+                param_name: "amount",
+            ): Scalar(-0.0000000014901161),
+            (
+                node_idx: 14,
+                param_name: "selection",
+            ): Selection("1"),
+            (
+                node_idx: 4,
+                param_name: "rotate",
+            ): Vector((-0.0, 0.0, -0.0)),
+            (
+                node_idx: 21,
+                param_name: "selection",
+            ): Selection("20, 18"),
+            (
+                node_idx: 4,
+                param_name: "translate",
+            ): Vector((0.0, 0.0, 0.0)),
+            (
+                node_idx: 16,
+                param_name: "divisions",
+            ): Scalar(3.0),
+            (
+                node_idx: 47,
+                param_name: "x",
+            ): Scalar(1.4000001),
+            (
+                node_idx: 24,
+                param_name: "comment",
+            ): String("TODO: All this mess can be replaced with a \"Loop cut\" node once we have it..."),
+            (
+                node_idx: 44,
+                param_name: "translate",
+            ): Vector((0.0, 0.0, 0.0)),
+            (
+                node_idx: 29,
+                param_name: "radius",
+            ): Scalar(0.06999993),
+            (
+                node_idx: 44,
+                param_name: "scale",
+            ): Vector((0.5999999, 1.0, 0.5999999)),
+            (
+                node_idx: 6,
+                param_name: "comment",
+            ): String("Design credit goes to: https://www.artstation.com/artwork/2wvQe"),
+            (
+                node_idx: 31,
+                param_name: "center",
+            ): Vector((0.0, 0.0, 0.0)),
+            (
+                node_idx: 37,
+                param_name: "radius",
+            ): Scalar(0.087999955),
+            (
+                node_idx: 45,
+                param_name: "translate",
+            ): Vector((0.0, 0.0, 0.0)),
+            (
+                node_idx: 4,
+                param_name: "selection",
+            ): Selection("4, 6"),
+            (
+                node_idx: 4,
+                param_name: "geometry",
+            ): String("Halfedge"),
+            (
+                node_idx: 39,
+                param_name: "num_vertices",
+            ): Scalar(12.0),
+            (
+                node_idx: 36,
+                param_name: "x",
+            ): Scalar(0.15999997),
+            (
+                node_idx: 19,
+                param_name: "a",
+            ): Selection("26"),
+            (
+                node_idx: 46,
+                param_name: "z",
+            ): Scalar(0.0),
+            (
+                node_idx: 22,
+                param_name: "b",
+            ): Selection("23"),
+            (
+                node_idx: 33,
+                param_name: "rotate",
+            ): Vector((1.5687635, 0.0, -0.0)),
+            (
+                node_idx: 23,
+                param_name: "a",
+            ): Selection("30"),
+            (
+                node_idx: 31,
+                param_name: "radius",
+            ): Scalar(1.0),
+            (
+                node_idx: 31,
+                param_name: "rings",
+            ): Scalar(6.0),
+            (
+                node_idx: 48,
+                param_name: "op",
+            ): String("Mul"),
+            (
+                node_idx: 18,
+                param_name: "a",
+            ): Selection("24"),
+            (
+                node_idx: 25,
+                param_name: "b",
+            ): Selection("33"),
+            (
+                node_idx: 44,
+                param_name: "rotate",
+            ): Vector((0.0, 0.0, 0.0)),
+            (
+                node_idx: 43,
+                param_name: "amount",
+            ): Scalar(0.040000003),
+            (
+                node_idx: 26,
+                param_name: "a",
+            ): Selection("26"),
+            (
+                node_idx: 11,
+                param_name: "origin",
+            ): Vector((0.0, 0.0, 0.0)),
+            (
+                node_idx: 23,
+                param_name: "b",
+            ): Selection("24"),
+            (
+                node_idx: 17,
+                param_name: "a",
+            ): Selection("23"),
+            (
+                node_idx: 27,
+                param_name: "center",
+            ): Vector((0.0, -0.24251501, 0.0)),
+            (
+                node_idx: 1,
+                param_name: "amount",
+            ): Scalar(0.20000002),
+            (
+                node_idx: 39,
+                param_name: "radius",
+            ): Scalar(0.087999955),
+            (
+                node_idx: 20,
+                param_name: "a",
+            ): Selection("21"),
+            (
+                node_idx: 21,
+                param_name: "translate",
+            ): Vector((0.0, -0.07062015, 0.0)),
+            (
+                node_idx: 33,
+                param_name: "translate",
+            ): Vector((0.0, -0.87222886, 0.0)),
+            (
+                node_idx: 39,
+                param_name: "center",
+            ): Vector((0.0, -0.7373852, 0.0)),
+            (
+                node_idx: 32,
+                param_name: "amount",
+            ): Scalar(-0.1),
+            (
+                node_idx: 25,
+                param_name: "a",
+            ): Selection("27"),
+            (
+                node_idx: 7,
+                param_name: "size",
+            ): Vector((0.39999992, 0.29999992, 0.09999993)),
+            (
+                node_idx: 41,
+                param_name: "radius",
+            ): Scalar(0.087999955),
+            (
+                node_idx: 3,
+                param_name: "faces",
+            ): Selection("1"),
+            (
+                node_idx: 45,
+                param_name: "scale",
+            ): Vector((0.9999978, 0.9999995, 0.9999996)),
+            (
+                node_idx: 41,
+                param_name: "height",
+            ): Scalar(0.10000002),
+            (
+                node_idx: 2,
+                param_name: "geometry",
+            ): String("Halfedge"),
+            (
+                node_idx: 16,
+                param_name: "edges",
+            ): Selection("14,29,25,8,0,2"),
+            (
+                node_idx: 11,
+                param_name: "size",
+            ): Vector((0.4999999, 0.39999992, 0.18999992)),
+            (
+                node_idx: 41,
+                param_name: "num_vertices",
+            ): Scalar(12.0),
+            (
+                node_idx: 37,
+                param_name: "center",
+            ): Vector((0.0, -0.9953418, 0.0)),
+            (
+                node_idx: 37,
+                param_name: "height",
+            ): Scalar(0.10000002),
+            (
+                node_idx: 7,
+                param_name: "origin",
+            ): Vector((0.0, 0.0022652, 0.0)),
+            (
+                node_idx: 10,
+                param_name: "translate",
+            ): Vector((0.0, -0.14350758, 0.0)),
+            (
+                node_idx: 48,
+                param_name: "y",
+            ): Scalar(0.5),
+            (
+                node_idx: 17,
+                param_name: "b",
+            ): Selection("6"),
+            (
+                node_idx: 15,
+                param_name: "amount",
+            ): Scalar(-0.3),
+            (
+                node_idx: 2,
+                param_name: "translate",
+            ): Vector((0.0, -0.053346395, 0.0)),
+            (
+                node_idx: 44,
+                param_name: "geometry",
+            ): String("Face"),
+            (
+                node_idx: 21,
+                param_name: "scale",
+            ): Vector((1.0, 1.0, 1.2973732)),
+            (
+                node_idx: 32,
+                param_name: "faces",
+            ): Selection("0..24"),
+            (
+                node_idx: 27,
+                param_name: "radius",
+            ): Scalar(0.087999955),
+            (
+                node_idx: 20,
+                param_name: "b",
+            ): Selection("27"),
+            (
+                node_idx: 1,
+                param_name: "faces",
+            ): Selection("1"),
+            (
+                node_idx: 29,
+                param_name: "height",
+            ): Scalar(1.1500001),
+            (
+                node_idx: 19,
+                param_name: "b",
+            ): Selection("20"),
+            (
+                node_idx: 45,
+                param_name: "rotate",
+            ): Vector((0.67127615, 0.5895251, -0.37466446)),
+            (
+                node_idx: 2,
+                param_name: "selection",
+            ): Selection("4, 6"),
+            (
+                node_idx: 46,
+                param_name: "x",
+            ): Scalar(0.0),
+        },
+    )),
+)


### PR DESCRIPTION
~Fixes: #95.~

It turns out that #95 was just user error.

However, I think this PR might still be useful, as it adds a "bounding_box" method to Rust, and a "line_with_normals" function to Lua, in addition to a "helix.lua" node.

![fixed-2023-10-09_21-14-06](https://github.com/gmlewis/blackjack/assets/6598971/d4e90120-1e03-40eb-bba0-07cd685e71e3)
